### PR TITLE
fix filtered_search's text_scope and accent_insensitive_regexp

### DIFF
--- a/ubiquo_core/lib/ubiquo/filtered_search.rb
+++ b/ubiquo_core/lib/ubiquo/filtered_search.rb
@@ -100,7 +100,7 @@ module Ubiquo
         regexp_op = connection.adapter_name == "PostgreSQL" ? "~*" : "REGEXP"
         @enabled_scopes.concat [:text]
         scope :text, lambda { |value|
-          match = accent_insensitive_regexp(value.downcase.gsub(/[%_\?\(\)]/) { |x| "\\" + x })
+          match = accent_insensitive_regexp(value)
           matches = fields.inject([]) { |r, f| r << match }
           conditions = fields.map { |f| "lower(#{table_name}.#{f}) #{regexp_op} ?" }.join(" OR ")
           where(conditions, *matches)
@@ -128,7 +128,7 @@ module Ubiquo
       end
 
       def accent_insensitive_regexp(text)
-        pattern = /(\^|\$|\?|\+|\[|\]|\(|\)|\'|\"|\.|\*|\/|\-|\\|\|)/
+        pattern = /(%|_|\^|\$|\?|\+|\[|\]|\(|\)|\'|\"|\.|\*|\/|\-|\\|\|)/
         text = text.gsub(pattern){|match|"\\"  + match}
         regexps = ["(a|á|à|â|ã|A|Á|À|Â|Ã)", "(e|é|è|ê|E|É|È|Ê)", "(i|í|ì|I|Í|Ì)", "(o|ó|ò|ô|õ|O|Ó|Ò|Ô|Õ)", "(u|ú|ù|U|Ú|Ù)", "(c|ç|C|Ç)", "(ñ|Ñ)"]
         regexps.each { |exp| text.gsub! Regexp.new(exp), exp }

--- a/ubiquo_core/test/unit/ubiquo/filtered_search_test.rb
+++ b/ubiquo_core/test/unit/ubiquo/filtered_search_test.rb
@@ -37,6 +37,9 @@ class FilteredSearchTest < ActiveSupport::TestCase
       assert_equal [@m.find_by_title('Tíred')], @m.filtered_search({'filter_text' => 'TIred'})
       assert_equal [@m.find_by_description('òuch réally?')], @m.filtered_search({'filter_text' => 'òuch réally?'})
       assert_equal [@m.find_by_description('bah loot')], @m.filtered_search({'filter_text' => 'niña'})
+      assert_equal [@m.find_by_title('Special Symbols')], @m.filtered_search({'filter_text' => 'parenthesis('})
+      assert_equal [@m.find_by_title('Special Symbols')], @m.filtered_search({'filter_text' => 'question?'})
+      assert_equal [@m.find_by_title('Special Symbols')], @m.filtered_search({'filter_text' => 'plus+'})
     end
   end
 
@@ -159,6 +162,11 @@ class FilteredSearchTest < ActiveSupport::TestCase
      },
      { :title => 'Tíred',
        :description => 'stop',
+       :published_at => Date.tomorrow,
+       :private => false
+     },
+     { :title => 'Special Symbols',
+       :description => 'parenthesis(question?plus+',
        :published_at => Date.tomorrow,
        :private => false
      }


### PR DESCRIPTION
Using text scope with some special symbols did not work properly (eg: "(") as gsub was applied twice, duplicating the backslashes in some cases.

Tests were not run as I wasn't able to make the project work (gem versions errors probably).