### PR TITLE
rescues ActionView::MissingTemplate for specific formats

### DIFF
--- a/ubiquo_design/lib/ubiquo_design/init_settings.rb
+++ b/ubiquo_design/lib/ubiquo_design/init_settings.rb
@@ -45,6 +45,7 @@ Ubiquo::Plugin.register(:ubiquo_design, :plugin => UbiquoDesign) do |config|
     permit?("expiration_management")
   }
   config.add(:public_host, lambda{|options| 'replaceme.com'})
+  config.add :rescue_missing_template, []
 end
 
 groups = Ubiquo::Settings.get :model_groups


### PR DESCRIPTION
rescues ActionView::MissingTemplate for specific formats and raises ActionController::RoutingError instead

specify formats via ubiquo settings, eg:

```
Ubiquo::Settings.context(:ubiquo_design).set do |config|
  config.rescue_missing_template = ["image/png"]
end
```